### PR TITLE
remove preventDefault that was added to resolve bubbling event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Event Bubbling in handleClick `BaseOverlay`.
+
 ## [0.1.2] - 2020-04-07
 ### Fixed
 - Typings of `BaseTrigger`, `BaseOverlay`, `OverlayLayout` and `OverlayTrigger`.

--- a/react/BaseOverlay.tsx
+++ b/react/BaseOverlay.tsx
@@ -139,7 +139,6 @@ export default function BaseOverlay(props: Props) {
         // The Trigger works as a toggle, so if this event
         // go up to the Trigger it will close the Overlay
         e.stopPropagation()
-        // e.preventDefault()
       }
 
       if (onClick) {

--- a/react/BaseOverlay.tsx
+++ b/react/BaseOverlay.tsx
@@ -139,7 +139,7 @@ export default function BaseOverlay(props: Props) {
         // The Trigger works as a toggle, so if this event
         // go up to the Trigger it will close the Overlay
         e.stopPropagation()
-        e.preventDefault()
+        // e.preventDefault()
       }
 
       if (onClick) {


### PR DESCRIPTION
#### What problem is this solving?

PreventDefault was added to solve bubbling event, but it was already solving with stopPropagation, this behavior was affecting the utilization with other components inside overlay layout, like forms and etc...

#### How to test it?

Clicking in the bottom-right overlay badge(teste) and then clicking in "enviar" in the form. The expected behavior is a simple HTML validation error


[Workspace](https://iespinoza--compradiretaempresas.myvtex.com/politicas-de-privacidade)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/13649073/95100234-493f9000-0707-11eb-8e3a-4210562e510e.png)

#### Describe alternatives you've considered, if any.

You can test the behavior with stopPropagation with the problem in [this workspace](https://ramonteste--compradiretaempresas.myvtex.com/politicas-de-privacidade)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3o6fIQrLNf2cJ76zII/giphy.gif)
